### PR TITLE
Fix partition key error

### DIFF
--- a/MovieMVC/Models/DocumentDBRepository.cs
+++ b/MovieMVC/Models/DocumentDBRepository.cs
@@ -54,9 +54,12 @@ namespace MovieMVC
             {
                 if (e.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
+                    var documentCollection = new DocumentCollection { Id = CollectionId };
+                    documentCollection.PartitionKey.Paths.Add("/id");
+
                     await client.CreateDocumentCollectionAsync(
                         UriFactory.CreateDatabaseUri(DatabaseId),
-                        new DocumentCollection { Id = CollectionId },
+                        documentCollection,
                         new RequestOptions { OfferThroughput = 1000 });
                 }
                 else


### PR DESCRIPTION
If you let the application create the collection, it wasn't adding a partition key, so when querying it with the id as the partition key, was erroring with "Partition key provided either doesn't correspond to definition in the collection or doesn't match partition key field values specified in the document."

Other option was to not specify the partition key in the queries, which would also work for collections below 10GB.