### PR TITLE
Fix partition key for edit and delete

### DIFF
--- a/MovieMVC/Models/DocumentDBRepository.cs
+++ b/MovieMVC/Models/DocumentDBRepository.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using Microsoft.Azure.Documents;
+﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Linq;
+using System;
+using System.Collections.Generic;
 using System.Configuration;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
 using System.Net;
+using System.Threading.Tasks;
 
 namespace MovieMVC
 {
@@ -96,15 +93,15 @@ namespace MovieMVC
 
         public static async Task<Document> RemoveItemAsync(string id, T item)
         {
-            Document document = await client.ReadDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id), new RequestOptions { PartitionKey = new PartitionKey(id) });
-            return await client.DeleteDocumentAsync(document.SelfLink, new RequestOptions { PartitionKey = new PartitionKey(id) });
+            Document document = await client.ReadDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id));
+            return await client.DeleteDocumentAsync(document.SelfLink);
         }
 
         public static async Task<T> GetItemAsync(string id)
         {
             try
             {
-                Document document = await client.ReadDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id), new RequestOptions { PartitionKey = new PartitionKey(id) });
+                Document document = await client.ReadDocumentAsync(UriFactory.CreateDocumentUri(DatabaseId, CollectionId, id));
                 return (T)(dynamic)document;
             }
             catch (DocumentClientException e)


### PR DESCRIPTION
I was unable to edit or delete an item. Was getting: 

> Partition key provided either doesn't correspond to definition in the collection or doesn't match partition key field values specified in the document. Microsoft.Azure.Documents.Common/1.21.0.0

I just remove the `RequestOptions`, they had changed the collections, and now we don`t have the PartitionKey when creating it. 